### PR TITLE
 1,匹配平台组针对静态信息库的导入导出功能。

### DIFF
--- a/Dubbo/src/main/java/com/hzgc/dubbo/staticrepo/SrecordTable.java
+++ b/Dubbo/src/main/java/com/hzgc/dubbo/staticrepo/SrecordTable.java
@@ -12,4 +12,5 @@ public class SrecordTable implements Serializable {
     public static final String RESULTS = "results";      // 人员信息列表
     public static final String PHOTOID = "photoid";     // 照片ID
     public static final String PHOTO = "photo";          // 照片
+    public static final String PSEARCH_MODEL = "searchmodel";     // 搜索模型。
 }

--- a/HBase/src/main/java/com/hzgc/hbase/staticrepo/ObjectInfoHandlerImpl.java
+++ b/HBase/src/main/java/com/hzgc/hbase/staticrepo/ObjectInfoHandlerImpl.java
@@ -470,10 +470,14 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
                         pSearchArgsModel.isMoHuSearch(),
                         pSearchArgsModel.getStart(),
                         pSearchArgsModel.getPageSize());
+                putSearchRecordToHBase(pSearchArgsModel.getPaltaformId(), objectSearchResult,
+                        pSearchArgsModel.getImage(), pSearchArgsModel);
                 break;
             }
             case "searchByRowkey": {
                 objectSearchResult = searchByRowkey(pSearchArgsModel.getRowkey());
+                putSearchRecordToHBase(pSearchArgsModel.getPaltaformId(), objectSearchResult,
+                        pSearchArgsModel.getImage(), pSearchArgsModel);
                 break;
             }
             case "searchByCphone": {
@@ -485,12 +489,16 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
                 objectSearchResult = searchByCreator(pSearchArgsModel.getCreator(),
                         pSearchArgsModel.isMoHuSearch(),
                         pSearchArgsModel.getStart(), pSearchArgsModel.getPageSize());
+                putSearchRecordToHBase(pSearchArgsModel.getPaltaformId(), objectSearchResult,
+                        pSearchArgsModel.getImage(), pSearchArgsModel);
                 break;
             }
             case "searchByName": {
                 objectSearchResult = searchByName(pSearchArgsModel.getName(),
                         pSearchArgsModel.isMoHuSearch(),
                         pSearchArgsModel.getStart(), pSearchArgsModel.getPageSize());
+                putSearchRecordToHBase(pSearchArgsModel.getPaltaformId(), objectSearchResult,
+                        pSearchArgsModel.getImage(), pSearchArgsModel);
                 break;
             }
             default: {
@@ -500,7 +508,7 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
                         pSearchArgsModel.getThredshold(), pSearchArgsModel.getPkeys(),
                         pSearchArgsModel.getCreator(), pSearchArgsModel.getCphone(),
                         pSearchArgsModel.getStart(), pSearchArgsModel.getPageSize(),
-                        pSearchArgsModel.isMoHuSearch());
+                        pSearchArgsModel.isMoHuSearch(), pSearchArgsModel);
                 break;
             }
         }
@@ -512,7 +520,7 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
     private ObjectSearchResult searchByMutiCondition(String platformId, String idCard, String name, int sex,
                                                      byte[] photo, String feature, float threshold,
                                                      List<String> pkeys, String creator, String cphone,
-                                                     int start, int pageSize, boolean moHuSearch) {
+                                                     int start, int pageSize, boolean moHuSearch, PSearchArgsModel pSearchArgsModel) {
         SearchRequestBuilder requestBuilder;
         if (start == -1) {
             start = 1;
@@ -608,7 +616,8 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
             LOG.info("以图搜图的时候，先根据条件进行过滤花费时间是：" + (System.currentTimeMillis() - startTime));
             ObjectSearchResult objectSearchResult = searchByPhotoAndThreshold(filteredBaseRepo,threshold, feature);
             objectSearchResult = HBaseUtil.dealWithPaging(objectSearchResult, start, pageSize);
-            putSearchRecordToHBase(platformId, objectSearchResult, photo);
+            putSearchRecordToHBase(platformId, objectSearchResult,
+                    photo, pSearchArgsModel);
             return objectSearchResult;
         }
 
@@ -696,7 +705,7 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
         }
 
         ObjectSearchResult tmp = HBaseUtil.dealWithPaging(objectSearchResult_Tmp, start, pageSize);
-        putSearchRecordToHBase(platformId, tmp, null);
+        putSearchRecordToHBase(platformId, tmp, null, pSearchArgsModel);
         return tmp;
     }
 
@@ -752,7 +761,6 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
             LOG.info("根据rowkey获取对象信息的时候异常............");
             searchResult.setSearchStatus(1);
             e.printStackTrace();
-            putSearchRecordToHBase(null, searchResult, null);
             return searchResult;
         } finally {
             HBaseUtil.closTable(table);
@@ -1049,6 +1057,91 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
                     Bytes.toBytes(searchResult.getSearchStatus()))
                     .addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.SEARCH_NUMS),
                             Bytes.toBytes(searchResult.getSearchNums()));
+            if (platformId != null) {
+                put.addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.PLATFORM_ID),
+                        Bytes.toBytes(platformId));
+            }
+            if (searchResult.getPhotoId() != null) {
+                put.addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.PHOTOID),
+                        Bytes.toBytes(searchResult.getPhotoId()));
+            }
+            if (results != null) {
+                put.addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.RESULTS), results);
+            }
+            if (photo != null) {
+                put.addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.PHOTO), photo);
+            }
+            try {
+                table.put(put);
+            } catch (IOException e) {
+                LOG.info("excute putSearchRecordToHBase failed.");
+                e.printStackTrace();
+            } finally {
+                HBaseUtil.closTable(table);
+                LOG.info("putSearchRecordToHBase, time: " + (System.currentTimeMillis() - start));
+            }
+        }
+    }
+    // 保存历史查询记录
+    private void putSearchRecordToHBase(String platformId, ObjectSearchResult searchResult, byte[] photo,
+                                        PSearchArgsModel pSearchArgsModel) {
+        long start = System.currentTimeMillis();
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        ObjectOutputStream oout = null;
+        byte[] results = null;
+        byte[] searchModel = null;
+        if (searchResult != null) {
+            List<Map<String, Object>> persons = searchResult.getResults();
+            if (persons != null) {
+                for (Map<String, Object> person : persons) {
+                    Iterator<Map.Entry<String, Object>> it = person.entrySet().iterator();
+                    while (it.hasNext()) {
+                        Map.Entry<String, Object> entry = it.next();
+                        String key = entry.getKey();
+                        if (ObjectInfoTable.FEATURE.equals(key)) {
+                            it.remove();
+                        }
+                    }
+                }
+            }
+            try {
+                oout = new ObjectOutputStream(bout);
+                oout.writeObject(new ArrayList(searchResult.getResults()));
+                results = bout.toByteArray();
+                oout.flush();
+                bout = new ByteArrayOutputStream();
+                oout = new ObjectOutputStream(bout);
+                oout.writeObject(pSearchArgsModel);
+                searchModel = bout.toByteArray();
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally {
+                try {
+                    if (oout != null) {
+                        oout.close();
+                    }
+                    bout.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        if (searchResult != null) {
+            Table table = HBaseHelper.getTable(SrecordTable.TABLE_NAME);
+            String srecordRowKey = searchResult.getSearchId();
+            if (srecordRowKey == null) {
+                LOG.info("putSearchRecordToHBase, failed:  rowkey cannnot be null.");
+                return;
+            }
+            Put put = new Put(Bytes.toBytes(srecordRowKey));
+            put.setDurability(Durability.ASYNC_WAL);
+            LOG.info("srecord rowkey is:  " + searchResult.getSearchId());
+            put.addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.SEARCH_STATUS),
+                    Bytes.toBytes(searchResult.getSearchStatus()))
+                    .addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.SEARCH_NUMS),
+                            Bytes.toBytes(searchResult.getSearchNums()));
+            put.addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.PSEARCH_MODEL),
+                    searchModel);
             if (platformId != null) {
                 put.addColumn(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.PLATFORM_ID),
                         Bytes.toBytes(platformId));

--- a/HBase/src/main/java/com/hzgc/hbase/staticrepo/SearchRecordHandlerImpl.java
+++ b/HBase/src/main/java/com/hzgc/hbase/staticrepo/SearchRecordHandlerImpl.java
@@ -1,6 +1,7 @@
 package com.hzgc.hbase.staticrepo;
 
 import com.hzgc.dubbo.staticrepo.ObjectSearchResult;
+import com.hzgc.dubbo.staticrepo.PSearchArgsModel;
 import com.hzgc.dubbo.staticrepo.SearchRecordHandler;
 import com.hzgc.dubbo.staticrepo.SrecordTable;
 import com.hzgc.hbase.util.HBaseHelper;
@@ -19,12 +20,20 @@ import org.apache.log4j.*;
 public class SearchRecordHandlerImpl implements SearchRecordHandler {
     private static Logger LOG = Logger.getLogger(SearchRecordHandlerImpl.class);
 
+    /**
+     * 处理流程，根据rowkey 取得当时的搜索条件，然后重新想数据库房一次请求
+     * @param rowkey，即Hbase 数据库中的rowkey，查询记录唯一标志
+     * @param from  返回的查询记录中，从哪一条开始
+     * @param size  需要返回的记录数
+     * @return
+     */
     @Override
     public ObjectSearchResult getRocordOfObjectInfo(String rowkey,int from,int size) {
+        ObjectInfoHandlerImpl objectInfoHandler = new ObjectInfoHandlerImpl();
         Table table = HBaseHelper.getTable(SrecordTable.TABLE_NAME);
         Get get = new Get(Bytes.toBytes(rowkey));
         ObjectSearchResult objectSearchResult = new ObjectSearchResult();
-        List<Map<String,Object>> filterList = null;
+        PSearchArgsModel pSearchArgsModel = null;
         Result result = null;
         try {
             result = table.get(get);
@@ -32,42 +41,19 @@ public class SearchRecordHandlerImpl implements SearchRecordHandler {
             LOG.error("get data by rowkey from srecord table failed! used method getRocordOfObjectInfo.");
             e.printStackTrace();
         }
+        byte[] searchModelByte = null;
         if (result != null) {
-            String useString = result + ".";
-            if (useString.contains(SrecordTable.SEARCH_STATUS)) {
-                objectSearchResult.setSearchStatus(Bytes.toInt(result.getValue(Bytes.toBytes(SrecordTable.RD_CLOF),
-                        Bytes.toBytes(SrecordTable.SEARCH_STATUS))));
-            }
-            if(useString.contains(SrecordTable.PHOTOID)) {
-                objectSearchResult.setPhotoId(Bytes.toString(result.getValue(Bytes.toBytes(SrecordTable.RD_CLOF),
-                        Bytes.toBytes(SrecordTable.PHOTOID))));
-            }
-            objectSearchResult.setSearchId(rowkey);
-            if (useString.contains(SrecordTable.SEARCH_NUMS)) {
-                objectSearchResult.setSearchNums(Bytes.toLong(result.getValue(Bytes.toBytes(SrecordTable.RD_CLOF),
-                        Bytes.toBytes(SrecordTable.SEARCH_NUMS))));
-            }
-            if(useString.contains(SrecordTable.RESULTS)) {
-                byte[] resultBySearch = result.getValue(Bytes.toBytes(SrecordTable.RD_CLOF),
-                        Bytes.toBytes(SrecordTable.RESULTS));
-                ObjectInputStream ois;
-                List<Map<String, Object>> results;
-                try {
-                    ois = new ObjectInputStream(new ByteArrayInputStream(resultBySearch));
-                    results = (List<Map<String, Object>>) ois.readObject();
-                    if(from + size - 1 < results.size()) {
-                        filterList = results.subList(from - 1, from + size - 1);
-                    }else{
-                        filterList = results.subList(from - 1, results.size());
-                    }
-                } catch (Exception e) {
-                    LOG.error("change the results format from the method getRocordOfObjectInfo failed!");
-                    e.printStackTrace();
-                } finally {
-                    HBaseUtil.closTable(table);
-                }
-                objectSearchResult.setResults(filterList);
-            }
+           searchModelByte = result.getValue(Bytes.toBytes(SrecordTable.RD_CLOF), Bytes.toBytes(SrecordTable.PSEARCH_MODEL));
+        }
+        ObjectInputStream ois;
+        try {
+            ois = new ObjectInputStream(new ByteArrayInputStream(searchModelByte));
+            pSearchArgsModel = (PSearchArgsModel) ois.readObject();
+            objectSearchResult = objectInfoHandler.getObjectInfo(pSearchArgsModel);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
         }
         return objectSearchResult;
     }


### PR DESCRIPTION
修改人   ：  李第亮
修改内容： （功能点：匹配平台组导出查询静态信息库信息。）
                   1，修改保存历史记录接口，现在的思路是，保存当时的查询条件。
                   2，修改历史记录查询接口，根据查询历史ID，找出当时的条件，替换开始行和要返回的条数。
所属模块： Dubbo 和 Hbase
合入人：
合入时间：