### PR TITLE
静态信息库保存历史记录bug

### DIFF
--- a/HBase/src/main/java/com/hzgc/hbase/staticrepo/ObjectInfoHandlerImpl.java
+++ b/HBase/src/main/java/com/hzgc/hbase/staticrepo/ObjectInfoHandlerImpl.java
@@ -1093,6 +1093,7 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
         if (searchResult != null) {
             List<Map<String, Object>> persons = searchResult.getResults();
             if (persons != null) {
+                // 保存的数据中去掉feature，历史结果中不用保存feature
                 for (Map<String, Object> person : persons) {
                     Iterator<Map.Entry<String, Object>> it = person.entrySet().iterator();
                     while (it.hasNext()) {
@@ -1106,8 +1107,11 @@ public class ObjectInfoHandlerImpl implements ObjectInfoHandler {
             }
             try {
                 oout = new ObjectOutputStream(bout);
-                oout.writeObject(new ArrayList(searchResult.getResults()));
-                results = bout.toByteArray();
+                List<Map<String, Object>> persons_tmp = searchResult.getResults();
+                if (persons_tmp != null){
+                    oout.writeObject(new ArrayList(searchResult.getResults()));
+                    results = bout.toByteArray();
+                }
                 oout.flush();
                 bout = new ByteArrayOutputStream();
                 oout = new ObjectOutputStream(bout);


### PR DESCRIPTION
修改人 ： 李第亮
修改内容： 
                  修改HBase 静态信息库历史记录保存，当搜索历史为空的时候，会报空指针异常。从而根据rowkey 等相应条件搜索时，会空指针。
所属模块： HBase
合入人：赵喆
合入时间：2017-11-09