### PR TITLE
小文件合并Bug 修复

### DIFF
--- a/Cluster/bin/schema-merge-final-table-crash.sh
+++ b/Cluster/bin/schema-merge-final-table-crash.sh
@@ -33,7 +33,7 @@ declare -r CLUSTER_DIR=${BIGDATA_SERVICE_DIR}/cluster
 RELEASE_VERSION=1.5.0
 
 hdfsClusterName=$(sed -n '1p' ${CONF_DIR}/merget-parquet-files.properties)
-tmpTableHdfsPath=$(sed -n '2p' ${CONF_DIR}/merget-parquet-files.properties)
+tmpTableHdfsPath=$(sed -n '3p' ${CONF_DIR}/merget-parquet-files.properties)
 hisTableHdfsPath=$(sed -n '3p' ${CONF_DIR}/merget-parquet-files.properties)
 tableName=$(sed -n '4p' ${CONF_DIR}/merget-parquet-files.properties)
 

--- a/Cluster/bin/schema-merge-final-table.sh
+++ b/Cluster/bin/schema-merge-final-table.sh
@@ -33,7 +33,7 @@ declare -r CLUSTER_DIR=${BIGDATA_SERVICE_DIR}/cluster
 RELEASE_VERSION=1.5.0
 
 hdfsClusterName=$(sed -n '1p' ${CONF_DIR}/merget-parquet-files.properties)
-tmpTableHdfsPath=$(sed -n '2p' ${CONF_DIR}/merget-parquet-files.properties)
+tmpTableHdfsPath=$(sed -n '3p' ${CONF_DIR}/merget-parquet-files.properties)
 hisTableHdfsPath=$(sed -n '3p' ${CONF_DIR}/merget-parquet-files.properties)
 tableName=$(sed -n '4p' ${CONF_DIR}/merget-parquet-files.properties)
 dateString=""

--- a/Cluster/src/main/resources/sparkJob.properties
+++ b/Cluster/src/main/resources/sparkJob.properties
@@ -35,5 +35,5 @@ job.zkDirAndPort=
 job.kafkaToEs.zkPaths=/es
 job.kafkaToParquet.zkPaths=/parquet
 job.repartition.number=3
-job.storeAddress=hdfs://hzgc/user/hive/warehouse/mid_table
+job.storeAddress=hdfs://hzgc/user/hive/warehouse/mid_table/
 job.backupAddress=hdfs://hzgc/checkpoint/mid_backup

--- a/Cluster/src/main/scala/com/hzgc/cluster/consumer/KafkaToParquet.scala
+++ b/Cluster/src/main/scala/com/hzgc/cluster/consumer/KafkaToParquet.scala
@@ -1,7 +1,7 @@
 package com.hzgc.cluster.consumer
 
 import java.sql.Timestamp
-import java.util.Properties
+import java.util.{Properties, UUID}
 
 import com.google.common.base.Stopwatch
 import com.hzgc.cluster.util.StreamingUtils
@@ -77,7 +77,8 @@ object KafkaToParquet {
     })
     kafkaDF.foreachRDD(rdd => {
       import spark.implicits._
-      rdd.map(rdd => rdd._1).repartition(1).toDF().write.mode(SaveMode.Append).parquet(storeAddress)
+      rdd.map(rdd => rdd._1).repartition(1).toDF().write.mode(SaveMode.Append)
+               .parquet(storeAddress + "/" + UUID.randomUUID().toString.replace("-",""))
       rdd.foreachPartition(parData => {
         val putDataToEs = PutDataToEs.getInstance()
         parData.foreach(data => {

--- a/Cluster/src/main/scala/com/hzgc/cluster/smallfile/MergeParquetFile.scala
+++ b/Cluster/src/main/scala/com/hzgc/cluster/smallfile/MergeParquetFile.scala
@@ -56,12 +56,12 @@ object MergeParquetFile {
     def main(args: Array[String]): Unit = {
         if (args.length != 4  && args.length != 5) {
             System.out.print(s"""
-                   |Usage: MergeParquetFile <hdfsClusterName> <tmpTableHdfsPath> <hisTableHdfsPath> <tableName> <dateString>
-                   |<hdfsClusterName> 例如：hdfs://hacluster或者hdfs://hzgc
-                   |<tmpTableHdfsPath> 临时表的根目录，需要是绝对路径
-                   |<hisTableHdfsPath> 合并后的parquet文件，即总的或者历史文件的根目录，需要是绝对路径
-                   |<tableName> 表格名字，最终保存的动态信息库的表格名字
-                   |<dateString > 用于表示需要合并的某天的内容
+                                |Usage: MergeParquetFile <hdfsClusterName> <tmpTableHdfsPath> <hisTableHdfsPath> <tableName> <dateString>
+                                |<hdfsClusterName> 例如：hdfs://hacluster或者hdfs://hzgc
+                                |<tmpTableHdfsPath> 临时表的根目录，需要是绝对路径
+                                |<hisTableHdfsPath> 合并后的parquet文件，即总的或者历史文件的根目录，需要是绝对路径
+                                |<tableName> 表格名字，最终保存的动态信息库的表格名字
+                                |<dateString > 用于表示需要合并的某天的内容
                  """.stripMargin)
             System.exit(1)
         }
@@ -96,7 +96,7 @@ object MergeParquetFile {
         }
         val pathArr : Array[String] = new Array[String](parquetFiles.size())
         var count = 0
-        while (count < parquetFiles.size()) {
+        while (count < parquetFiles.size() && count <= 10000) {
             pathArr(count) = parquetFiles.get(count)
             count = count + 1
         }
@@ -111,7 +111,8 @@ object MergeParquetFile {
             personDF.persist()
             if (personDF.count() == 0) {
                 LOG.info("there are parquet files, but no data in parquet files, just to delete the files.")
-                ReadWriteHDFS.del(pathArr, fs);
+                // 删除临时表格中的文件
+                ReadWriteHDFS.delV2(pathArr, fs);
                 System.exit(2)
             }
             personDF.printSchema()
@@ -124,6 +125,7 @@ object MergeParquetFile {
                 .parquet(tmpPath)
             val setOfTempTable : util.Set[String] = new util.HashSet[String]()
             ReadWriteHDFS.getPartitions(new Path(tmpPath), fs, setOfTempTable)
+            // 删除临时目录
             ReadWriteHDFS.del(Array(tmpPath), fs)
 
             // 4, 遍历hisTableHdfsPath目录，最终表格的根目录，得到时间和设备对应关系set02
@@ -148,7 +150,8 @@ object MergeParquetFile {
             personDF.persist()
             if (personDF.count() == 0) {
                 LOG.info("there are parquet files, but no data in parquet files, just to delete the files.")
-                ReadWriteHDFS.del(pathArr, fs);
+                // 删除最终表格中的文件
+                ReadWriteHDFS.del(pathArr, fs)
                 System.exit(2)
             }
             personDF.printSchema()
@@ -162,7 +165,13 @@ object MergeParquetFile {
             .parquet(hisTableHdfsPath)
 
         // 7,删除原来的文件
-        ReadWriteHDFS.del(pathArr, fs);
+        if (dateString == null || dateString.equals("")) {
+            // 删除临时表格上的文件
+            ReadWriteHDFS.delV2(pathArr, fs)
+        } else {
+            // 删除最终表格上的文件
+            ReadWriteHDFS.del(pathArr, fs)
+        }
 
         // 8, Reflesh spark store crash table data
         if (dateString == null || "".equals(dateString)) {
@@ -218,6 +227,17 @@ object ReadWriteHDFS {
     def del(paths : Array[String], fs : FileSystem): Unit = {
         for (f <- paths) {
             fs.delete(new Path(f), true)
+        }
+    }
+
+    /**
+      * 删除文件，ture 表示迭代删除目录或者文件
+      * @param paths  文件列表
+      * @param fs  hdfs文件系统实例
+      */
+    def delV2(paths : Array[String], fs : FileSystem): Unit = {
+        for (f <- paths) {
+            fs.delete(new Path(f.substring(0, f.lastIndexOf("/"))), true)
         }
     }
 
@@ -286,5 +306,4 @@ object ReadWriteHDFS {
         }
     }
 }
-
 


### PR DESCRIPTION
修改人： 李第亮
修改内容：
1，修改小文件合并脚本Bug，合并最终表格的脚本有误。
2，Streaming 生成的parquet 文件，一个文件一个目录，避免并行执行时对同一个目录操坐使程序挂掉。
3，合并小文件适配streaming 程序的修改，以及避免读取过多的小文件而使得程序无法运行。
修改模块：cluster
合入人：赵喆
合入时间：2018-1-3