### PR TITLE
CommonConf及获取资源文件数据方法

### DIFF
--- a/FtpServer/src/main/java/com/hzgc/collect/expand/conf/CommonConf.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/conf/CommonConf.java
@@ -1,5 +1,8 @@
 package com.hzgc.collect.expand.conf;
 
+import com.hzgc.collect.expand.util.ClusterOverFtpProperHelper;
+import com.hzgc.collect.expand.util.HelperFactory;
+
 public class CommonConf {
 
     /**
@@ -37,6 +40,11 @@ public class CommonConf {
      * 默认加载类路径下的cluster-over-ftp.properties文件
      */
     public CommonConf() {
+        HelperFactory.regist();
+        this.capacity = Integer.valueOf(ClusterOverFtpProperHelper.getCapacity());
+        this.receiveLogDir = ClusterOverFtpProperHelper.getReceiveLogDir();
+        this.processLogDir = ClusterOverFtpProperHelper.getProcessLogDir();
+        this.receiveNumber = Integer.valueOf(ClusterOverFtpProperHelper.getReceiveNumber());
 
     }
 

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/util/ClusterOverFtpProperHelper.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/util/ClusterOverFtpProperHelper.java
@@ -2,6 +2,7 @@ package com.hzgc.collect.expand.util;
 
 import com.hzgc.util.common.FileUtil;
 import org.apache.log4j.Logger;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
@@ -16,6 +17,10 @@ public class ClusterOverFtpProperHelper extends ProperHelper {
     private static String port;
     private static String implicitSsl;
     private static String threadNum;
+    private static String capacity;
+    private static String receiveLogDir;
+    private static String processLogDir;
+    private static String receiveNumber;
 
     static {
         String properName = "cluster-over-ftp.properties";
@@ -26,6 +31,10 @@ public class ClusterOverFtpProperHelper extends ProperHelper {
             setPort();
             setImplicitSsl();
             setThreadNum();
+            setCapacity();
+            setReceiveLogDir();
+            setProcessLogDir();
+            setReceiveNumber();
 
         } catch (IOException e) {
             e.printStackTrace();
@@ -49,6 +58,21 @@ public class ClusterOverFtpProperHelper extends ProperHelper {
         threadNum = verifyPositiveIntegerValue("thread.number", "3", props, log);
     }
 
+    private static String setCapacity() {
+        return capacity = verifyPositiveIntegerValue("capacity", String.valueOf(Integer.MAX_VALUE), props, log);
+    }
+
+    private static String setReceiveLogDir() {
+        return receiveLogDir = verifyCommonValue("receiveLogDir", "/opt/", props, log);
+    }
+
+    private static String setProcessLogDir() {
+        return processLogDir = verifyCommonValue("processLogDir", "/opt/", props, log);
+    }
+
+    private static String setReceiveNumber() {
+        return receiveNumber = verifyCommonValue("receiveNumber", String.valueOf(0), props, log);
+    }
 
     /**
      * get方法。提供获取配置文件中的值的方法。
@@ -67,6 +91,26 @@ public class ClusterOverFtpProperHelper extends ProperHelper {
     public static String getThreadNum() {
         log.info("Load the configuration thread.number, the value is \"" + threadNum + "\"");
         return threadNum;
+    }
+
+    public static String getCapacity() {
+        log.info("Load the configuration capacity, the value is \"" + capacity + "\"");
+        return capacity;
+    }
+
+    public static String getReceiveLogDir() {
+        log.info("Load the configuration receiveLogDir, the value is \"" + receiveLogDir + "\"");
+        return receiveLogDir;
+    }
+
+    public static String getProcessLogDir() {
+        log.info("Load the configuration processLogDir, the value is \"" + processLogDir + "\"");
+        return processLogDir;
+    }
+
+    public static String getReceiveNumber() {
+        log.info("Load the configuration receiveNumber, the value is \"" + receiveNumber + "\"");
+        return receiveNumber;
     }
 }
 


### PR DESCRIPTION
修改人：刘善彬
修改内容：
 FtpServer模块：CommonConf默认加载cluster-over-ftp.properties资源文件；ClusterOverFtpProperHelper
 类获取capacity，receiveLogDir，processLogDir，receiveNumber字段设置数据。
合入人：赵喆
合入时间：2018-01-27
分支：ceph