### PR TITLE
重构merge模块。

### DIFF
--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FileFactory.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FileFactory.java
@@ -33,7 +33,7 @@ class FileFactory {
      */
 
     private void setAllProcessFiles() {
-        allProcessFiles = fileUtil.listAllProcessFileDir(processParentDir, writingLogFile);
+        allProcessFiles = fileUtil.listAllExecutableFileDir(processParentDir, writingLogFile);
     }
 
 

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FileFactory.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FileFactory.java
@@ -7,8 +7,10 @@ import java.util.List;
  * 数据封装类：FileFactory（马燊偲）
  * 成员变量含义：
  * processParentDir：process日志的根目录
- * processFile：process日志根目录下所有文件
- * receiveFilePath：根据某一个process日志路径，获得的对应receive日志路径
+ * writingLogFile：CommonConf中的logName（000000.log）
+ * allBackupLog：process日志根目录下所有除了0000.log、最大日志、error日志以外，
+ *                      所有其他可以移到备份目录的日志文件
+ * allFiles：process目录下，所有的文件
  */
 class FileFactory {
 
@@ -16,7 +18,7 @@ class FileFactory {
 
     private  String processParentDir;
     private String writingLogFile;
-    private  List<String> allProcessFiles;
+    private  List<String> allBackupLog;
     private  List<String> allFiles;
 
     //有参构造函数，传入需处理的日志根路径，
@@ -24,24 +26,39 @@ class FileFactory {
     FileFactory(String processLogDir, String writingLogFile) {
         this.processParentDir = processLogDir;
         this.writingLogFile = writingLogFile;
-        setAllProcessFiles();
+        setAllBackupLog();
     }
 
     /**
      * set方法
-     * 列出process日志根目录下所有文件
      */
 
-    private void setAllProcessFiles() {
-        allProcessFiles = fileUtil.listAllExecutableFileDir(processParentDir, writingLogFile);
+    /**
+     * 列出process日志根目录下所有文件
+     */
+    public void setAllFiles(List<String> allFiles) {
+        allFiles = fileUtil.listAllFileAbsPath(processParentDir);
     }
+
+    /**
+     * 列出process日志根目录下所有除了0000.log、最大日志、error日志以外，
+     * 所有其他可以移到备份目录的日志文件
+     */
+    private void setAllBackupLog() {
+        allBackupLog = fileUtil.listAllBackupLogAbsPath(processParentDir, writingLogFile);
+    }
+
 
 
     /**
      * get方法
      */
-    List<String> getAllProcessFiles() {
-        return allProcessFiles;
+    public List<String> getAllFiles() {
+        return allFiles;
+    }
+
+    List<String> getAllBackupLog() {
+        return allBackupLog;
     }
 
 }

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FileFactory.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FileFactory.java
@@ -15,11 +15,15 @@ class FileFactory {
     private  FileUtil fileUtil = new FileUtil();
 
     private  String processParentDir;
+    private String writingLogFile;
     private  List<String> allProcessFiles;
+    private  List<String> allFiles;
 
-    //有参构造函数，传入需处理的日志根路径
-    FileFactory(String processLogDir) {
+    //有参构造函数，传入需处理的日志根路径，
+    // 以及CommonConf中的logName（000000.log）
+    FileFactory(String processLogDir, String writingLogFile) {
         this.processParentDir = processLogDir;
+        this.writingLogFile = writingLogFile;
         setAllProcessFiles();
     }
 
@@ -29,8 +33,9 @@ class FileFactory {
      */
 
     private void setAllProcessFiles() {
-        allProcessFiles = fileUtil.listAllFileOfDir(processParentDir);
+        allProcessFiles = fileUtil.listAllProcessFileDir(processParentDir, writingLogFile);
     }
+
 
     /**
      * get方法

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FileFactory.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FileFactory.java
@@ -14,7 +14,7 @@ import java.util.List;
  */
 class FileFactory {
 
-    private  FileUtil fileUtil = new FileUtil();
+    private MergeUtil mergeUtil = new MergeUtil();
 
     private  String processParentDir;
     private String writingLogFile;
@@ -37,7 +37,7 @@ class FileFactory {
      * 列出process日志根目录下所有文件
      */
     public void setAllFiles(List<String> allFiles) {
-        allFiles = fileUtil.listAllFileAbsPath(processParentDir);
+        allFiles = mergeUtil.listAllFileAbsPath(processParentDir);
     }
 
     /**
@@ -45,7 +45,7 @@ class FileFactory {
      * 所有其他可以移到备份目录的日志文件
      */
     private void setAllBackupLog() {
-        allBackupLog = fileUtil.listAllBackupLogAbsPath(processParentDir, writingLogFile);
+        allBackupLog = mergeUtil.listAllBackupLogAbsPath(processParentDir, writingLogFile);
     }
 
 

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FindDiffRows.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/FindDiffRows.java
@@ -11,10 +11,9 @@ import java.util.*;
  * 其中包含以下三个方法：
  * <p>
  * getNotProRows：获取集合中未处理的所有行；
- * getErrProRows：获取集合中处理失败的所有行；
  * getAllDiffRows：获取集合中不同行；
  */
-public class FindDiffRows {
+class FindDiffRows {
     private Logger LOG = Logger.getLogger(FindDiffRows.class);
 
     /**
@@ -23,9 +22,8 @@ public class FindDiffRows {
      * @param allRows 日志合并后的所有行
      * @return List对象  未处理数据的集合
      */
-    public List<String> getNotProRows(List<String> allRows) {
+    List<String> getNotProRows(List<String> allRows) {
         List<String> notProList = new ArrayList<>();
-        String row;
         if (allRows == null || allRows.size() == 0) {
             LOG.warn("The unionAllRows size is None");
         } else if (allRows.size() == 1) {
@@ -63,34 +61,9 @@ public class FindDiffRows {
                 notProList.add(allRows.get(allRows.size() - 1));
             }
         }
+        Collections.sort(notProList, new ListComparator());
         return notProList;
     }
-
-    /**
-     * 获取合并后日志中数据处理失败的集合
-     *
-     * @param allRows 日志合并后的所有行
-     * @return List对象  合并后集合中数据处理失败的集合
-     */
-    public List<String> getErrProRows(List<String> allRows) {
-        List<String> failList = new ArrayList<>();
-        String tmp;
-        if (allRows == null || allRows.size() == 0) {
-            LOG.warn("The unionAllRows size is None");
-        } else {
-            Collections.sort(allRows);
-            for (String allRow : allRows) {
-                LogEvent event = JSONHelper.toObject(allRow, LogEvent.class);
-                String processState = event.getStatus();
-                //根据状态是否为零判断数据是否处理成功
-                if (!processState.equals("0")) {
-                    failList.add(allRow);
-                }
-            }
-        }
-        return failList;
-    }
-
 
     /**
      * 获取集合中不同行
@@ -98,7 +71,7 @@ public class FindDiffRows {
      * @param allRows 合并后日志集合
      * @return List对象       返回合并后不同行的集合
      */
-    public List<String> getAllDiffRows(List<String> allRows) {
+    List<String> getAllDiffRows(List<String> allRows) {
         List<String> rows = new ArrayList<>();
         String row;
         if (allRows == null || allRows.size() == 0) {
@@ -122,7 +95,17 @@ public class FindDiffRows {
             }
 
         }
+        Collections.sort(rows, new ListComparator());
         return rows;
     }
 
+
+    private class ListComparator implements Comparator<String> {
+        @Override
+        public int compare(String row1, String row2) {
+            LogEvent event1 = JSONHelper.toObject(row1, LogEvent.class);
+            LogEvent event2 = JSONHelper.toObject(row2, LogEvent.class);
+            return Long.compare(event1.getCount(), event2.getCount());
+        }
+    }
 }

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/MergeUtil.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/MergeUtil.java
@@ -17,11 +17,11 @@ import java.util.regex.Pattern;
 
 
 /**
- * 与文件读写相关的工具类（马燊偲）
+ * merge模块与文件读写相关的工具类（马燊偲）
  */
-public class FileUtil {
+public class MergeUtil {
 
-    private Logger LOG = Logger.getLogger(FileUtil.class);
+    private Logger LOG = Logger.getLogger(MergeUtil.class);
     //系统换行符
     private String newLine = System.getProperty("line.separator");
     private static final String SUFFIX = ".log";

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverErrProData.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverErrProData.java
@@ -6,7 +6,6 @@ import com.hzgc.collect.expand.processer.FaceObject;
 import com.hzgc.collect.expand.processer.KafkaProducer;
 import com.hzgc.collect.expand.util.JSONHelper;
 import org.apache.log4j.Logger;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -14,44 +13,24 @@ import java.util.List;
 /**
  * 恢复处理出错的数据，作为Ftp的一个线程。（马燊偲）
  * 整体流程：
- * 1，遍历process 目录中的文件，得到日记文件的一个绝对路径，放入一个List中，proFilePaths
- * 2，判断proFilePaths是否为空（process 目录下是否有文件），若为空，结束；
- * 若不为空，遍历proFilePaths的每一个文件，例如如下：
- * 1，/opt/logdata/process/p-0/000000000001.log
- * 然后查看对应的 /opt/logdata/receive/r-0/000000000001.log 文件是否存在
- * （1）存在：
- * 1，读取两个文件的内容到一个List 里面，
- * 2，排序，对比，取得处理出错的数据列表 errProFiles
- * 3，遍历errProFiles，每一条出错数据存储到merge的receive目录下对应的文件名中，
- * 例如/opt/logdata/merge/receive/r-0/000000000001.log。
- * 并删除 /opt/logdata/process/p-0/000000000001.log  和
- * /opt/logdata/receive/r-0/000000000001.log
- * 4，遍历errProFiles，提取特征发送Kafka，
- * 同时把处理日记发送到/opt/logdata/merge/process/p-0/000000000001.log
- * （2）不存在：
- * 把/opt/logdata/process/p-0/000000000001.log 文件删除，跳过这层循环。
- * 2，遍历/opt/logdata/merge/process/下的所有文件，放到mergeProFilePaths中------->List
- * 3，遍历mergeProFilePaths
- * 1，得到比如/opt/logdata/merge/process/p-0/000000000001.log，
- * 和文件/opt/logdata/merge/receive/r-0/000000000001.log 进行对比
- * 2，把/opt/logdata/merge/receive/r-0/000000000001.log
- * 和 /opt/logdata/merge/receive/r-0/000000000001.log 放到一个totalList  里
- * 3，对totalList 进行排序，比较，得到diffListV1，
- * 然后覆盖/opt/logdata/merge/receive/r-0/000000000001.log 的内容，
- * 1，diffListV1 没有内容，则跳过，有内容，进行下面的2
- * 2，遍历diffListV1,把处理的内容发送到Kafka ，
- * 同时把日记覆盖掉/opt/logdata/merge/process/r-0/000000000001.log
- * 4，对比/opt/logdata/merge/receive/r-0/000000000001.log  和
- * /opt/logdata/merge/receive/r-0/000000000001.log，获取两个文件出错的数据集合列表。
- * 1，若列表为空，则删除这两个文件。
- * 2，若不为空，不进行处理，退出程序。
+ * 1，扫描data/process/p-0/error/error.log这个文件，获取这个文件的状态。
+ *      A、若文件处于lock状态，结束；
+ *      B、若文件为unlock状态：
+ *          立即移动data/process/p-0/error/error.log到
+ *          /success/process/201802/p-0/error/error 2018-02-01-1522148-1758.log（用于备份）
+ *          和 /merge/process/p-0/error/error 2018-02-01-1522148-1963.log（用于恢复处理）
+ * 2，对 备份目录/merge/process/p-0/error/下的所有错误文件进行扫描，
+ *      将所有错误日志路径放入到一个List 里面，errLogPaths。遍历errLogPaths：
+ *      1，对于errLogPaths中每一个errorN.log，遍历其中每一条数据：
+ *              1，对每条数据，提取特征发送Kafka，
+ *              2，同时把发送失败的数据重新写到/merge/error/下的一个新的errorN-NEW日志中，
+ *      2，删除原有已处理过的错误日志errorN.log。
  * 3，结束
  */
 public class RecoverErrProData implements Runnable {
 
     private Logger LOG = Logger.getLogger(RecoverErrProData.class);
     private final SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd");
-    private static final String MERGE_PRO_PATH = "/opt/logdata/merge/process/";
     private static CommonConf commonConf;
 
     //构造函数
@@ -65,163 +44,64 @@ public class RecoverErrProData implements Runnable {
         FileUtil fileUtil = new FileUtil();
         LogEvent logEvent = new LogEvent();
 
-        //获取processLog的根目录
+        //获取processLog的根目录：/opt/RealTimeFaceCompare/ftp/data/process
         String processLogDir = commonConf.getProcessLogDir();
-        //调用FileFactory，传入process日志根目录
-        FileFactory fileFactory = new FileFactory(processLogDir);
-        //获取所有process日记文件的绝对路径，放入一个List中（proFilePaths）
-        List<String> proFilePaths = fileFactory.getAllProcessFiles();
+        //获取process/error下的error日志
+        String errorFile = processLogDir + "/error/error.log";
+        //获取merge/error目录：/opt/RealTimeFaceCompare/ftp/merge/error
+        String mergeErrLogDir = commonConf.getMergeLogDir() + "/error";
+        //获取error.log需要移动到的success和merge目录下的路径
+        String successErrFile = fileUtil.getSuccessFilePath(errorFile);
+        String mergeErrFile = fileUtil.getMergeFilePath(errorFile);
+        //移动到merge后，拷贝一份到success
+        fileUtil.moveErrFile(errorFile, mergeErrFile); //其中包括判断锁是否存在
+        fileUtil.copyFile(mergeErrFile, successErrFile);
 
-        //若proFilePaths这个list不为空（process日志根目录下有日志）
-        if (proFilePaths != null && proFilePaths.size() != 0) { // V1 if start
-            for (String processFile : proFilePaths) {
-                String receiveFile = fileUtil.getRecFileFromProFile(processFile);
-                //判断processFile文件对应的receiveFile是否存在
-                if (!fileUtil.isFileExist(receiveFile)) { // V1-A if start
-                    //若对应的receiveFile不存在，删除这个processFile
-                    LOG.info("Not found receiveFile, delete processFile :" + processFile);
-                    fileUtil.deleteFile(processFile);
-                } else { //若processFile文件对应的receiveFile存在，则获取处理出错的数据
-                    //获取队列ID
-                    String queueID = processFile.substring(processFile.lastIndexOf("-") + 1, processFile.lastIndexOf("/"));
-                    //初始化RowsListFactory工厂类
-                    RowsListFactory rowsListFactory = new RowsListFactory(processFile, receiveFile);
-                    //调用getErrProRows()方法，取出processFile和receiveFile中处理出错的数据
-                    List<String> errProFiles = rowsListFactory.getErrProRows();
+        //获取merge/error下所有error日记文件的绝对路径，放入一个List中（errLogPaths）
+        List<String> errLogPaths = fileUtil.listAllFileDir(mergeErrLogDir);
+        //若errLogPaths这个list不为空（merge/error下有错误日志）
+        if (errLogPaths != null && errLogPaths.size() != 0) { // V-1 if start
+            for (String errorPath : errLogPaths) {
+                //获取每个error.log中每一行数据
+                List<String> errorRows = fileUtil.getAllContentFromFile(errorPath);
+                //判断errorRows是否为空，若不为空，则需要处理出错数据
+                if (errorRows != null && errorRows.size() != 0) { // V-2 if start
+                    for (String row : errorRows) {
+                        //用JSONHelper将某行数据转化为LogEvent格式
+                        LogEvent event = JSONHelper.toObject(row, LogEvent.class);
 
-                    //判断errProFiles是否为空，若不为空，则需要处理出错数据
-                    if (errProFiles != null && errProFiles.size() != 0) { // V1-B if start
-                        for (String row : errProFiles) {
-                            //用JSONHelper将某行数据转化为LogEvent格式
-                            LogEvent event = JSONHelper.toObject(row, LogEvent.class);
-                            //根据processFile的日志路径，获取对应mergeReceiveFile的日志路径
-                            String mergeRecFilePath = fileUtil.getMergeRecFilePath(receiveFile);
-                            //将errProFiles中每一条数据，保存到merge 的receive目录下对应的文件名中
-                            fileUtil.writeMergeFile(event, mergeRecFilePath);
+                        //每一条记录的格式为：
+                        //"count":0, "url":"ftp://s100:/2018/01/09", "timestamp":"2018-01-02", "status":"0"
+                        //用LogEvent获取该条数据的ftpUrl
+                        String ftpUrl = event.getPath();
+                        //获取该条数据的序列号
+                        long count = event.getCount();
+                        //根据路径取得对应的图片，并提取特征，封装成FaceObject，发送Kafka
+                        FaceObject faceObject = GetFaceObject.getFaceObject(row);
+                        if (faceObject != null) { // V-3 if start
+                            SendDataToKafka sendDataToKafka = SendDataToKafka.getSendDataToKafka();
+                            sendDataToKafka.sendKafkaMessage(KafkaProducer.getFEATURE(), ftpUrl, faceObject);
+                            boolean success = sendDataToKafka.isSuccessToKafka();
 
-                            //每一条记录的格式为：
-                            //"count":0, "url":"ftp://s100:/2018/01/09", "timestamp":"2018-01-02", "status":"0"
-                            //用LogEvent获取该条数据的ftpUrl
-                            String ftpUrl = event.getPath();
-                            //获取该条数据的序列号
-                            long count = event.getCount();
-
-                            //根据路径取得对应的图片，并提取特征，封装成FaceObject，发送Kafka
-                            FaceObject faceObject = GetFaceObject.getFaceObject(row);
-                            if (faceObject != null) { // V1-C if start
-                                SendDataToKafka sendDataToKafka = SendDataToKafka.getSendDataToKafka();
-                                sendDataToKafka.sendKafkaMessage(KafkaProducer.getFEATURE(), ftpUrl, faceObject);
-                                boolean success = sendDataToKafka.isSuccessToKafka();
-
-                                //并向对应的merge/process/processFile中写入日志记录（发送kafka是否成功）
-                                LOG.info("Write log queueID is" + queueID + "" + processFile);
-                                //根据processFile的日志路径，获取对应mergeProcessFile的日志路径
-                                String mergeProFilePath = fileUtil.getMergeProFilePath(processFile);
-
-                                //向对应的merge/process/processFile写入日志
-                                logEvent.setPath(ftpUrl);
-                                if (success) {
-                                    logEvent.setStatus("0");
-                                } else {
-                                    logEvent.setStatus("1");
-                                }
-                                logEvent.setCount(count);
-                                logEvent.setTimeStamp(Long.valueOf(SDF.format(new Date())));
-                                fileUtil.writeMergeFile(event, mergeProFilePath);
-                            } // V1-C if end：faceObject不为空的判断结束
-                        }
-                    } // V1-B if end：errProFiles不为空的判断结束
-                    //删除原来的processFile和receiveFile
-                    fileUtil.deleteFile(processFile, receiveFile);
-                } // V1-A if end：processFile文件对应的receiveFile是否存在的判断结束
-            }
-
-            //扫描merge/process的根目录，得到处理过的日记文件的绝对路径mergeProFilePaths
-            FileFactory mergeFileFactory = new FileFactory(MERGE_PRO_PATH);
-            List<String> mergeProFilePaths = mergeFileFactory.getAllProcessFiles();
-            //若mergeProFilePaths这个list不为空（merge/process日志根目录下有日志）
-            if (mergeProFilePaths != null && mergeProFilePaths.size() != 0) { // V2 if start
-                for (String mergeProcessFile : mergeProFilePaths) {
-                    String mergeReceiveFile = fileUtil.getRecFileFromProFile(mergeProcessFile);
-                    //判断mergeProcessFile文件对应的mergeReceiveFile是否存在
-                    if (!fileUtil.isFileExist(mergeReceiveFile)) { // V2-A if start
-                        //若对应的mergeReceiveFile不存在，删除这个mergeProcessFile
-                        LOG.info("Not found mergeReceiveFile, delete mergeProcessFile :" + mergeProcessFile);
-                        fileUtil.deleteFile(mergeProcessFile);
-                    } else { //若mergeProcessFile文件对应的mergeReceiveFile存在，则获取处理出错的数据
-                        //获取队列ID
-                        String queueID = mergeProcessFile.substring(mergeProcessFile.lastIndexOf("-") + 1,
-                                mergeProcessFile.lastIndexOf("/"));
-                        //初始化RowsListFactory工厂类
-                        RowsListFactory rowsListFactoryV2 = new RowsListFactory(mergeProcessFile, mergeReceiveFile);
-                        //调用getErrProRows()方法，取出mergeProcessFile和mergeReceiveFile中处理出错的数据
-                        List<String> mergeErrProFiles = rowsListFactoryV2.getErrProRows();
-                        //删除原来的mergeProcessFile和mergeReceiveFile
-                        fileUtil.deleteFile(mergeProcessFile, mergeReceiveFile);
-
-                        //用mergeErrProFiles中的数据，覆盖原mergeReceiveFile日志中的内容
-                        // 例如/opt/logdata/merge/receive/r-0/000000000001.log
-                        for (String row : mergeErrProFiles) {
-                            //用JSONHelper将某行数据转化为LogEvent格式
-                            LogEvent event = JSONHelper.toObject(row, LogEvent.class);
-                            fileUtil.writeMergeFile(event, mergeReceiveFile);
-                        }
-                        //若mergeErrProFiles中无内容，跳过；若有内容：
-                        //遍历mergeErrProFiles，将内容发送到kafka，并覆盖日志/opt/logdata/merge/receive/r-0/000000000001.log
-                        if (mergeErrProFiles.size() != 0) { // V2-B if start
-                            for (String row : mergeErrProFiles) {
-                                LogEvent event = JSONHelper.toObject(row, LogEvent.class);
-                                //用LogEvent获取该条数据的ftpUrl
-                                String ftpUrl = event.getPath();
-                                //获取该条数据的序列号
-                                long count = event.getCount();
-
-                                //根据路径取得对应的图片，并提取特征，封装成FaceObject，发送Kafka
-                                FaceObject faceObject = GetFaceObject.getFaceObject(row);
-                                if (faceObject != null) { // V2-C if start
-                                    SendDataToKafka sendDataToKafka = SendDataToKafka.getSendDataToKafka();
-                                    sendDataToKafka.sendKafkaMessage(KafkaProducer.getFEATURE(), ftpUrl, faceObject);
-                                    boolean success = sendDataToKafka.isSuccessToKafka();
-
-                                    //并覆盖对应的merge/process/processFile日志记录（发送kafka是否成功）
-                                    LOG.info("Rewrite log queueID is" + queueID + "" + mergeProcessFile);
-                                    logEvent.setPath(ftpUrl);
-                                    if (success) {
-                                        logEvent.setStatus("0");
-                                    } else {
-                                        logEvent.setStatus("1");
-                                    }
-                                    logEvent.setCount(count);
-                                    logEvent.setTimeStamp(Long.valueOf(SDF.format(new Date())));
-                                    fileUtil.writeMergeFile(event, mergeProcessFile);
-                                } // V2-C if end：faceObject不为空的判断结束
-
-                                //对比两个文件：/opt/logdata/merge/receive/r-0/000000000001.log
-                                //                 和 /opt/logdata/merge/process/p-0/000000000001.log
-                                //获取两个文件出错的数据集合列表
-                                RowsListFactory rowsListFactoryV3 = new RowsListFactory(mergeProcessFile, mergeReceiveFile);
-                                List<String> mergeErrProFilesV2 = rowsListFactoryV3.getErrProRows();
-                                //若列表为空，则删除这两个文件。若不为空，不进行处理，退出程序。
-                                if (mergeErrProFilesV2 == null || mergeErrProFilesV2.size() == 0) {
-                                    LOG.info("There is no error data in " + mergeProcessFile + " and "
-                                            + mergeReceiveFile + ", delete these two files！");
-                                    fileUtil.deleteFile(mergeProcessFile, mergeReceiveFile);
-                                } else { //do nothing
-                                    LOG.warn("Waiting for next time to handle the error data in "
-                                            + mergeProcessFile + ", exit program!");
-                                }
+                            //若发送kafka不成功，将错误日志写入/merge/error/下一个新的errorN-NEW日志中
+                            String mergeErrFileNew = mergeErrFile+"-N";
+                            logEvent.setPath(ftpUrl);
+                            if (success) {
+                                logEvent.setStatus("0");
+                            } else {
+                                logEvent.setStatus("1");
                             }
-                        } else { //若mergeErrProFiles中无内容
-                            LOG.info("There is no error data in " + mergeProcessFile + " and " + mergeReceiveFile + "!");
-                        } // V2-B if end：mergeErrProFiles中有无内容的判断结束
-                    } // V2-A if end：对mergeProcessFile文件对应的mergeReceiveFile存在的判断结束
-                }
-            } else { //若merge/process日志目录下无日志
-                LOG.info("Nothing in " + MERGE_PRO_PATH);
-            } // V2 if end： merge/process日志目录下有无日志的判断结束
-        } else { //若proFilePaths这个list为空（process日志根目录下无日志），结束
-            LOG.info("Nothing in " + processLogDir);
-        }// V1 if end：对process日志根目录下是否有日志的判断结束
-
+                            logEvent.setCount(count);
+                            logEvent.setTimeStamp(Long.valueOf(SDF.format(new Date())));
+                            fileUtil.writeMergeFile(event, mergeErrFileNew);
+                        } // V-3 if end：faceObject不为空的判断结束
+                    }
+                } // V-2 if end：errorRows为空的判断结束
+                //删除已处理过的error日志
+                fileUtil.deleteFile(mergeErrFile);
+            }
+        } else { //若merge/error目录下无日志
+            LOG.info("Nothing in " + errLogPaths);
+        } // V-1 if end：对merge/error下是否有日志的判断结束
     }
 }

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverErrProData.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverErrProData.java
@@ -45,7 +45,7 @@ public class RecoverErrProData implements Runnable {
     @Override
     public void run() {
         //初始化FileUtil工具类
-        FileUtil fileUtil = new FileUtil();
+        MergeUtil mergeUtil = new MergeUtil();
         LogEvent logEvent = new LogEvent();
 
         //获取processLog的根目录：/opt/RealTimeFaceCompare/ftp/data/process
@@ -54,24 +54,24 @@ public class RecoverErrProData implements Runnable {
         String mergeErrLogDir = commonConf.getMergeLogDir() + "/error";
 
         //列出process目录下所有error日志路径
-        List<String> allErrorDir = fileUtil.listAllErrorLogAbsPath(processLogDir);
+        List<String> allErrorDir = mergeUtil.listAllErrorLogAbsPath(processLogDir);
         for (String errFile:allErrorDir) {
             //获取每个error.log需要移动到的success和merge目录下的路径
-            String successErrFile = fileUtil.getSuccessFilePath(errFile);
-            String mergeErrFile = fileUtil.getMergeFilePath(errFile);
+            String successErrFile = mergeUtil.getSuccessFilePath(errFile);
+            String mergeErrFile = mergeUtil.getMergeFilePath(errFile);
             //移动到merge后，拷贝一份到success
-            fileUtil.lockAndMove(errFile, mergeErrFile); //其中包括判断锁是否存在
-            fileUtil.copyFile(mergeErrFile, successErrFile);
+            mergeUtil.lockAndMove(errFile, mergeErrFile); //其中包括判断锁是否存在
+            mergeUtil.copyFile(mergeErrFile, successErrFile);
         }
 
         //获取merge/error下所有error日记文件的绝对路径，放入一个List中（errLogPaths）
-        List<String> errFilePaths = fileUtil.listAllFileAbsPath(mergeErrLogDir);
+        List<String> errFilePaths = mergeUtil.listAllFileAbsPath(mergeErrLogDir);
         //若errLogPaths这个list不为空（merge/error下有错误日志）
         if (errFilePaths != null && errFilePaths.size() != 0) { // V-1 if start
             //对于每一个error.log
             for (String errorFilePath : errFilePaths) {
                 //获取其中每一行数据
-                List<String> errorRows = fileUtil.getAllContentFromFile(errorFilePath);
+                List<String> errorRows = mergeUtil.getAllContentFromFile(errorFilePath);
                 //判断errorRows是否为空，若不为空，则需要处理出错数据
                 if (errorRows != null && errorRows.size() != 0) { // V-2 if start
                     for (String row : errorRows) {
@@ -101,12 +101,12 @@ public class RecoverErrProData implements Runnable {
                             }
                             logEvent.setCount(count);
                             logEvent.setTimeStamp(Long.valueOf(SDF.format(new Date())));
-                            fileUtil.writeMergeFile(event, mergeErrFileNew);
+                            mergeUtil.writeMergeFile(event, mergeErrFileNew);
                         } // V-3 if end：faceObject不为空的判断结束
                     }
                 } // V-2 if end：errorRows为空的判断结束
                 //删除已处理过的error日志
-                fileUtil.deleteFile(errorFilePath);
+                mergeUtil.deleteFile(errorFilePath);
             }
         } else { //若merge/error目录下无日志
             LOG.info("Nothing in " + mergeErrLogDir);

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverNotProData.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverNotProData.java
@@ -1,7 +1,6 @@
 package com.hzgc.collect.expand.merge;
 
 import com.hzgc.collect.expand.conf.CommonConf;
-import com.hzgc.collect.expand.log.DataProcessLogWriter;
 import com.hzgc.collect.expand.log.LogEvent;
 import com.hzgc.collect.expand.processer.FaceObject;
 import com.hzgc.collect.expand.processer.KafkaProducer;
@@ -41,7 +40,7 @@ public class RecoverNotProData {
 
 
     public boolean RecoverNotProData(CommonConf commonConf) {
-        FileUtil fileUtil = new FileUtil();
+        MergeUtil mergeUtil = new MergeUtil();
         LogEvent logEvent = new LogEvent();
         String processLogDir = commonConf.getProcessLogDir();
         //获取正在写的日志队列文件
@@ -59,9 +58,9 @@ public class RecoverNotProData {
         if (processFiles != null && processFiles.size() != 0) {
             for (String processFile : processFiles) {
                 //获取receive绝对路径
-                String receiveFile = fileUtil.getRecFilePathFromProFile(processFile);
+                String receiveFile = mergeUtil.getRecFilePathFromProFile(processFile);
                 //判断对应receive文件是否存在，存在则合并，不存在则移动位置
-                if (fileUtil.isFileExist(receiveFile)) {
+                if (mergeUtil.isFileExist(receiveFile)) {
                     RowsListFactory rowsListFactory = new RowsListFactory(processFile, receiveFile);
                     //获取未处理的数据
                     List<String> notProRows = rowsListFactory.getNotProRows();
@@ -88,12 +87,12 @@ public class RecoverNotProData {
                                 if (success) {
                                     logEvent.setStatus("0");
                                     LOG.info("Send to Kafka success,write log to processFile :" + processFile);
-                                    fileUtil.writeMergeFile(logEvent, processFile);
+                                    mergeUtil.writeMergeFile(logEvent, processFile);
                                 } else {
                                     //发送Kafka失败,将日志写到merge目录下的error日志文件中
                                     logEvent.setStatus("1");
                                     LOG.warn("Send to Kafka failure ,write log to errorLogFile :");
-                                    fileUtil.writeMergeFile(logEvent,writeErrFile);
+                                    mergeUtil.writeMergeFile(logEvent,writeErrFile);
                                 }
                                 recoverSuccess = true;
                             }
@@ -102,8 +101,8 @@ public class RecoverNotProData {
                 } else {
                     //对应receive 文件不存在，将process文件移动到success目录下
                     LOG.info("Can't find receiveFile,move processFile To SuccessDir");
-                    String successFilePath = fileUtil.getSuccessFilePath(processFile);
-                    fileUtil.moveFile(processFile, successFilePath);
+                    String successFilePath = mergeUtil.getSuccessFilePath(processFile);
+                    mergeUtil.moveFile(processFile, successFilePath);
                     recoverSuccess = true;
                 }
             }

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverNotProData.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverNotProData.java
@@ -51,7 +51,7 @@ public class RecoverNotProData {
         String mergeErrLogDir = commonConf.getMergeLogDir() + "/error";
         //要写入的merge/error日志路径：/opt/RealTimeFaceCompare/ftp/merge/error/error.log
         String writeErrFile = mergeErrLogDir + "/error.log";
-        List<String> processFiles = fileFactory.getAllProcessFiles();
+        List<String> processFiles = fileFactory.getAllFiles();
         //标记恢复数据是否成功，默认false
         boolean recoverSuccess = false;
 
@@ -59,7 +59,7 @@ public class RecoverNotProData {
         if (processFiles != null && processFiles.size() != 0) {
             for (String processFile : processFiles) {
                 //获取receive绝对路径
-                String receiveFile = fileUtil.getRecFileFromProFile(processFile);
+                String receiveFile = fileUtil.getRecFilePathFromProFile(processFile);
                 //判断对应receive文件是否存在，存在则合并，不存在则移动位置
                 if (fileUtil.isFileExist(receiveFile)) {
                     RowsListFactory rowsListFactory = new RowsListFactory(processFile, receiveFile);

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverNotProData.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RecoverNotProData.java
@@ -14,18 +14,43 @@ import java.util.List;
 
 /**
  * 恢复未处理的数据(曹大报)
+ *
+ *  * 整体流程：
+ * 1，根据CommonConf获取process根路径processLogDir；
+ * 2，遍历process 目录中的所有文件，得到日记文件的一个绝对路径，放入一个List中，processFiles；
+ *     判断 processFiles 是否为空(process 目录下是否有文件)；
+ *         1) processFiles不为空，遍历获取 processFiles 中每一个元素(process文件的绝对路径)，例如：/opt/logdata/process/p-0/000003000000.log；
+ *
+ *             根据process文件获取receive文件路径，判断对应receive文件(/opt/logdata/receive/r-0/000003000000.log)是否存在；
+ *             存在：
+ *                 1，读取process文件和receive文件，合并到一个List 里面(rowsListFactory)；
+ *                 2，排序，对比，获取有序的数据集合 notProRows；
+ *                 3，遍历 notProRows 每一条数据，提取特征获取faceObject发送Kafka；
+ *                     根据发送kafka是否成功分别写入不同日志文件中；
+ *                     第一条数据发送kafka失败；
+ *                         结束循环返回false；
+ *             不存在：
+ *                  把/opt/logdata/process/p-0/000003000000.log 文件移动到success目录下，跳过这层循环。
+ *         2）processFiles 为空
+ *             结束循环；
+ * 3，结束
  */
-public class RcoverNotProData {
-    private Logger LOG = Logger.getLogger(RcoverNotProData.class);
+public class RecoverNotProData {
+    private Logger LOG = Logger.getLogger(RecoverNotProData.class);
     private final SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd");
 
 
-    public boolean recoverNotProData(CommonConf commonConf) {
+    public boolean RecoverNotProData(CommonConf commonConf) {
         FileUtil fileUtil = new FileUtil();
         LogEvent logEvent = new LogEvent();
         String processLogDir = commonConf.getProcessLogDir();
-
-        FileFactory fileFactory = new FileFactory(processLogDir);
+        //获取正在写的日志队列文件
+        String writingLogFile = commonConf.getLogName();
+        FileFactory fileFactory = new FileFactory(processLogDir, writingLogFile);
+        //获取merge/error目录：/opt/RealTimeFaceCompare/ftp/merge/error
+        String mergeErrLogDir = commonConf.getMergeLogDir() + "/error";
+        //要写入的merge/error日志路径：/opt/RealTimeFaceCompare/ftp/merge/error/error.log
+        String writeErrFile = mergeErrLogDir + "/error.log";
         List<String> processFiles = fileFactory.getAllProcessFiles();
         //标记恢复数据是否成功，默认false
         boolean recoverSuccess = false;
@@ -35,11 +60,8 @@ public class RcoverNotProData {
             for (String processFile : processFiles) {
                 //获取receive绝对路径
                 String receiveFile = fileUtil.getRecFileFromProFile(processFile);
-                //判断对应receive文件是否存在，存在则合并，不存在则删除
+                //判断对应receive文件是否存在，存在则合并，不存在则移动位置
                 if (fileUtil.isFileExist(receiveFile)) {
-                    //获取队列ID
-                    String queueID = processFile.substring(processFile.lastIndexOf("-") + 1, processFile.lastIndexOf("/"));
-                    DataProcessLogWriter dataProcessLogWriter = new DataProcessLogWriter(commonConf, queueID);
                     RowsListFactory rowsListFactory = new RowsListFactory(processFile, receiveFile);
                     //获取未处理的数据
                     List<String> notProRows = rowsListFactory.getNotProRows();
@@ -59,27 +81,29 @@ public class RcoverNotProData {
                                 LOG.warn("first data send to Kafka failure");
                                 return false;
                             } else {
-                                LOG.info("Write log queueID is" + queueID + "" + processFile);
-                                //向对应的processfile中写入日志
+                                //向对应的processFile中写入日志
                                 logEvent.setPath(ftpUrl);
-                                if (success) {
-                                    logEvent.setStatus("0");
-                                } else {
-                                    logEvent.setStatus("1");
-                                }
                                 logEvent.setCount(count);
                                 logEvent.setTimeStamp(Long.valueOf(SDF.format(new Date())));
-                                dataProcessLogWriter.countCheckAndWrite(logEvent);
+                                if (success) {
+                                    logEvent.setStatus("0");
+                                    LOG.info("Send to Kafka success,write log to processFile :" + processFile);
+                                    fileUtil.writeMergeFile(logEvent, processFile);
+                                } else {
+                                    //发送Kafka失败,将日志写到merge目录下的error日志文件中
+                                    logEvent.setStatus("1");
+                                    LOG.warn("Send to Kafka failure ,write log to errorLogFile :");
+                                    fileUtil.writeMergeFile(logEvent,writeErrFile);
+                                }
                                 recoverSuccess = true;
                             }
                         }
                     }
                 } else {
-                    //对应receive 文件不存在，删除对应文件
-                    boolean deleteFile = fileUtil.deleteFile(processFile);
-                    if (!deleteFile) {
-                        LOG.warn("delete file " + processFile + "failure,please check it！");
-                    }
+                    //对应receive 文件不存在，将process文件移动到success目录下
+                    LOG.info("Can't find receiveFile,move processFile To SuccessDir");
+                    String successFilePath = fileUtil.getSuccessFilePath(processFile);
+                    fileUtil.moveFile(processFile, successFilePath);
                     recoverSuccess = true;
                 }
             }

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RowsListFactory.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RowsListFactory.java
@@ -13,7 +13,7 @@ import java.util.List;
 public class RowsListFactory {
 
     //初始化要用到的两个工具类
-    private  FileUtil fileUtil = new FileUtil();
+    private MergeUtil mergeUtil = new MergeUtil();
     private  FindDiffRows findDiffRows = new FindDiffRows();
 
     private  List<String> allDiffRows;
@@ -30,7 +30,7 @@ public class RowsListFactory {
      * set 方法
      */
     private void setAllDiffRows(String processFileDir, String receiveFileDir) {
-        List<String> allContentRows = fileUtil.getAllContentFromFile(processFileDir, receiveFileDir);
+        List<String> allContentRows = mergeUtil.getAllContentFromFile(processFileDir, receiveFileDir);
         allDiffRows = findDiffRows.getAllDiffRows(allContentRows);
     }
 

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RowsListFactory.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/RowsListFactory.java
@@ -24,7 +24,6 @@ public class RowsListFactory {
     public RowsListFactory(String processFileDir, String receiveFileDir){
         setAllDiffRows(processFileDir, receiveFileDir);
         setNotProRows();
-        setErrProRows();
     }
 
     /**
@@ -39,9 +38,6 @@ public class RowsListFactory {
         notProRows = findDiffRows.getNotProRows(allDiffRows);
     }
 
-    private void setErrProRows() {
-        errProRows = findDiffRows.getErrProRows(allDiffRows);
-    }
 
     /**
      * get 方法
@@ -54,7 +50,4 @@ public class RowsListFactory {
         return notProRows;
     }
 
-    public List<String> getErrProRows() {
-        return errProRows;
-    }
 }

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/merge/ScheRecoErrData.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/merge/ScheRecoErrData.java
@@ -1,0 +1,16 @@
+
+package com.hzgc.collect.expand.merge;
+
+        import com.hzgc.collect.expand.conf.CommonConf;
+
+        import java.util.concurrent.Executors;
+        import java.util.concurrent.ScheduledExecutorService;
+        import java.util.concurrent.TimeUnit;
+
+public class ScheRecoErrData {
+    public void scheduled(CommonConf conf) {
+        ScheduledExecutorService pool = Executors.newSingleThreadScheduledExecutor();
+        pool.scheduleAtFixedRate(new RecoverErrProData(conf), 5,
+                conf.getMergeScanTime(), TimeUnit.SECONDS);
+    }
+}

--- a/FtpServer/src/main/java/com/hzgc/collect/expand/util/ClusterOverFtpProperHelper.java
+++ b/FtpServer/src/main/java/com/hzgc/collect/expand/util/ClusterOverFtpProperHelper.java
@@ -98,11 +98,11 @@ public class ClusterOverFtpProperHelper extends ProperHelper {
     }
 
     private static void setSuccessLogDir() {
-        successLogDir = verifyCommonValue("success.log.dir","/opt/RealTimeFaceCompare/ftp/data/success", props, log);
+        successLogDir = verifyCommonValue("success.log.dir","/opt/RealTimeFaceCompare/ftp/success", props, log);
     }
 
     private static void setMergeLogDir() {
-        mergeLogDir = verifyCommonValue("merge.log.dir", "/opt/RealTimeFaceCompare/ftp/data/merge", props, log);
+        mergeLogDir = verifyCommonValue("merge.log.dir", "/opt/RealTimeFaceCompare/ftp/merge", props, log);
     }
 
     private static void setMergeScanTime() {

--- a/FtpServer/src/main/resources/cluster-over-ftp.properties
+++ b/FtpServer/src/main/resources/cluster-over-ftp.properties
@@ -13,10 +13,10 @@ receive.log.dir=/opt/RealTimeFaceCompare/ftp/data/receive
 process.log.dir=/opt/RealTimeFaceCompare/ftp/data/process
 
 #备份日志目录，用于存放已处理过的process和receive目录下的日志
-success.log.dir=/opt/RealTimeFaceCompare/ftp/data/success
+success.log.dir=/opt/RealTimeFaceCompare/ftp/success
 
 #merge模块处理日志目录
-merge.log.dir=/opt/RealTimeFaceCompare/ftp/data/merge
+merge.log.dir=/opt/RealTimeFaceCompare/ftp/merge
 
 #merge模块扫描处理的时间间隔
 merge.scan.time=


### PR DESCRIPTION
修改人：马燊偲&&曹大报
修改内容：重构merge模块：
1、修改fileutil工具类，添加移动文件方法、添加拷贝文件方法、添加获取锁移动错误日志方法、添加错误日志重命名方法等等。
2、修改RecoverErrProData的整个流程（从对比process/receive日志修改为直接读取error日志、获取锁等）
3、修改整个架构中冗余的部分，删除不用的方法。

修改模块：ftpserver-merge
修改时间：2018-02-05
合入人：赵喆
分支：ceph