### PR TITLE
修改parquet中多余的目录

### DIFF
--- a/Cluster/src/main/scala/com/hzgc/cluster/consumer/KafkaToParquet.scala
+++ b/Cluster/src/main/scala/com/hzgc/cluster/consumer/KafkaToParquet.scala
@@ -80,7 +80,7 @@ object KafkaToParquet {
     kafkaDF.foreachRDD(rdd => {
       import spark.implicits._
       rdd.map(rdd => rdd._1).repartition(1).toDF().write.mode(SaveMode.Append)
-          .parquet(storeAddress + "/" + UUID.randomUUID().toString.replace("-",""))
+          .parquet(storeAddress)
       rdd.foreachPartition(parData => {
         val putDataToEs = PutDataToEs.getInstance()
         parData.foreach(data => {


### PR DESCRIPTION
修改人：陈柯
修改内容：删除kafkaToparquet类中parquet不需要的多余目录
修改模块：cluster
合入人：赵喆
合入时间：2018-03-14
分支：v1.5.2